### PR TITLE
Support html5 documents

### DIFF
--- a/src/Spider/Parser.php
+++ b/src/Spider/Parser.php
@@ -10,10 +10,19 @@ class Spider_Parser implements Spider_ParserInterface
     {
         $document = new DOMDocument();
         $document->strictErrorChecking = false;
+
+        //Convert and repair as xhtml
+        $tidy     = new tidy;
+        $filtered = $tidy->repairString($content, array(
+            'output-xhtml' => true, //Ensure that void elements are closed (html5 void elements do not require closing)
+            'numeric-entities' => true, //Translate named entities to numeric entities (html5 does not have a dtd and chokes on named entities)
+        ));
+
         $document->loadXML(
-            $content,
+            $filtered,
             LIBXML_NOERROR | LIBXML_NONET | LIBXML_NOWARNING
         );
+
         $xpath = new DOMXPAth($document);
         $xpath->registerNamespace('xhtml', 'http://www.w3.org/1999/xhtml');
         return $xpath;


### PR DESCRIPTION
Fix two errors parsing html5 documents
- HTML5 does not have a DTD, so named entities can not be used when loading with domdocument.
- Ensure xhtml structure so that the document can be loaded with domdocument->loadXML.  (this adds closing for void elements such as <link>).
