### PR TITLE
improve the tidy parsing

### DIFF
--- a/src/Spider/Parser.php
+++ b/src/Spider/Parser.php
@@ -24,12 +24,14 @@ class Spider_Parser implements Spider_ParserInterface
             $content = $tidy->repairString($content, array(
                 'output-xhtml' => true, //Ensure that void elements are closed (html5 void elements do not require closing)
                 'numeric-entities' => true, //Translate named entities to numeric entities (html5 does not have a dtd and chokes on named entities)
+                'char-encoding' => 'utf8', //Enforce utf8 encoding
+                'hide-comments' => true, //don't output comments
             ));
         }
 
         $document->loadXML(
             $content,
-            LIBXML_NOERROR | LIBXML_NONET | LIBXML_NOWARNING
+            LIBXML_NOERROR | LIBXML_NONET | LIBXML_NOWARNING | LIBXML_NOCDATA
         );
 
         $xpath = new DOMXPAth($document);


### PR DESCRIPTION
- Remove comments as comments may contain stuff that domdocument does like
- enforce utf8 encoding
- set CDATA as text nodes
