### PR TITLE
Break out logic into separate accessible methods

### DIFF
--- a/src/Spider.php
+++ b/src/Spider.php
@@ -172,7 +172,9 @@ class Spider
     }
 
     /**
-     * @param $uri
+     * Download a page
+     * 
+     * @param string $uri the uri of the page to download
      * @return mixed - the content of the download
      */
     public function downloadPage($uri)
@@ -181,8 +183,10 @@ class Spider
     }
 
     /**
-     * @param $content
-     * @param $uri
+     * Page a page's content into xpath
+     * 
+     * @param string $content the html content of the page
+     * @param string $uri the uri of the page
      * @return mixed - the xpath data of the content
      */
     public function parsePage($content, $uri)
@@ -191,9 +195,11 @@ class Spider
     }
 
     /**
-     * @param $uri
-     * @param $depth
-     * @param $xpath
+     * Apply loggers to a page
+     * 
+     * @param string $uri The uri of the page
+     * @param string $depth The depth of the page scan
+     * @param string $xpath The xpath object for the page
      */
     public function logPage($uri, $depth, $xpath)
     {
@@ -203,10 +209,10 @@ class Spider
     }
 
     /**
-     * process a page
+     * Download, parse and log a page
      *
-     * @param $uri
-     * @param $depth
+     * @param string $uri The URI for the page
+     * @param string $depth The Depth of the page scan
      * @return mixed - the xpath for the page
      */
     public function processPage($uri, $depth)


### PR DESCRIPTION
It could be a system wants to use this library to download download a page, parse a page, run logs on  a page, or all of the above to a single page.
