### PR TITLE
Both http and https URLs should be considered 'internal'

### DIFF
--- a/src/Spider/Filter/External.php
+++ b/src/Spider/Filter/External.php
@@ -1,11 +1,11 @@
 <?php
 class Spider_Filter_External extends Spider_UriFilterInterface
 {
-    protected $baseuri = '';
+    protected $agnostic_baseuri;
 
     public function __construct(Iterator $iterator, $baseuri)
     {
-        $this->baseuri = $baseuri;
+        $this->agnostic_baseuri = $this->makeAgnostic($baseuri);
 
         parent::__construct($iterator);
     }
@@ -13,10 +13,23 @@ class Spider_Filter_External extends Spider_UriFilterInterface
     public function accept()
     {
         //Only get sub-pages of the baseuri
-        if (strncmp($this->baseuri, $this->current(), strlen($this->baseuri)) !== 0) {
+        $agnostic_uri = $this->makeAgnostic(($this->current()));
+
+        if (strncmp($this->agnostic_baseuri, $agnostic_uri, strlen($this->agnostic_baseuri)) !== 0) {
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Strip the http or https from a URL to make it agnostic
+     *
+     * @param $absolute_uri
+     * @return mixed
+     */
+    public function makeAgnostic($absolute_uri)
+    {
+        return preg_replace('/^https?:\/\//', '//', $absolute_uri);
     }
 }

--- a/tests/data/examplePage1.html
+++ b/tests/data/examplePage1.html
@@ -21,6 +21,7 @@
             <li><a href='/spidertest/directory1/doNotCrawl.html' title='page2'>Do not crawl</a></li>
             <li><a href='/spidertest/directory2/doNotCrawlWildcard.html' title='page2'>Do not crawl</a></li>
             <li><a href='snapchat://?u=test'>malformed</a></li>
+            <li><a href='https://wwww.basepage.com/spidertest/index.html'>https URL</a></li>
         </ul>
     </div>
     <p>

--- a/tests/spider.getCrawlableUris.phpt
+++ b/tests/spider.getCrawlableUris.phpt
@@ -50,6 +50,7 @@ http://wwww.basepage.com/spidertest/example/page2.html
 http://wwww.basepage.com/spidertest/page1.html
 http://wwww.basepage.com/spidertest/directory/
 http://wwww.basepage.com/spidertest/directory2/doNotCrawlWildcard.html
+https://wwww.basepage.com/spidertest/index.html
 http://wwww.basepage.com/spidertest/index.php
 Disallow useragent:
 http://wwww.basepage.com/spidertest/examplePage2.html
@@ -58,10 +59,12 @@ http://wwww.basepage.com/spidertest/example/page2.html
 http://wwww.basepage.com/spidertest/page1.html
 http://wwww.basepage.com/spidertest/directory/
 http://wwww.basepage.com/spidertest/directory2/doNotCrawlWildcard.html
+https://wwww.basepage.com/spidertest/index.html
 http://wwww.basepage.com/spidertest/index.php
 Disallow directory:
 http://wwww.basepage.com/spidertest/examplePage2.html
 http://wwww.basepage.com/spidertest/examplePage2.html
 http://wwww.basepage.com/spidertest/page1.html
 http://wwww.basepage.com/spidertest/directory/
+https://wwww.basepage.com/spidertest/index.html
 http://wwww.basepage.com/spidertest/index.php

--- a/tests/spider.getUris.phpt
+++ b/tests/spider.getUris.phpt
@@ -26,6 +26,7 @@ http://wwww.basepage.com/spidertest/directory/
 http://wwww.basepage.com/spidertest/directory1/doNotCrawl.html
 http://wwww.basepage.com/spidertest/directory2/doNotCrawlWildcard.html
 snapchat://?u=test
+https://wwww.basepage.com/spidertest/index.html
 http://wwww.basepage.com/spidertest/index.php
 mailto:test@example.com
 javascript:void(0)


### PR DESCRIPTION
If the base url started with http://, secure links were not considered as 'crawlable' because the base url was different (http vs https). This PR converts the absolute URLs to agnostic ones before they are compared, thus fixing the issue.