### PR TITLE
Correctly account for wildcards in robots.txt user-agent

### DIFF
--- a/src/Spider/Filter/RobotsTxt.php
+++ b/src/Spider/Filter/RobotsTxt.php
@@ -77,7 +77,7 @@ class Spider_Filter_RobotsTxt extends Spider_UriFilterInterface
 
             // Following rules only apply if User-agent matches $useragent or '*'
             if (preg_match('/^\s*User-agent: (.*)/i', $line, $match)) {
-                $ruleApplies = preg_match("/($agents)/i", $match[1]);
+                $ruleApplies = preg_match("/^($agents)/i", $match[1]);
             }
 
             if ($ruleApplies && preg_match('/^\s*Disallow:(.*)/i', $line, $regs)) {

--- a/tests/data/robots.txt
+++ b/tests/data/robots.txt
@@ -1,3 +1,6 @@
 User-agent: *
 Disallow: /spidertest/doNotCrawl.html
 Disallow: /spidertest/directory1/doNotCrawl.html
+
+User-agent: test*
+Disallow: /


### PR DESCRIPTION
This fixes an issue where the user agent would always match if the user-agent in the robots.txt file ended in an asterisk (something like `User-agent: test*`).